### PR TITLE
Swapped GPIO interface to use deprecated sysfs

### DIFF
--- a/brewery/Gopkg.lock
+++ b/brewery/Gopkg.lock
@@ -2,116 +2,226 @@
 
 
 [[projects]]
+  digest = "1:141635a36d65611d06a05ec1d17be950e386426b6540169fe7c9476df41f6493"
   name = "github.com/cpuguy83/go-md2man"
   packages = ["md2man"]
+  pruneopts = ""
   revision = "7762f7e404f8416dfa1d9bb6a8c192aa9acb4d19"
   version = "v1.0.10"
 
 [[projects]]
+  digest = "1:0deddd908b6b4b768cfc272c16ee61e7088a60f7fe2f06c547bd3d8e1f8b8e77"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = ""
   revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
   version = "v1.1.1"
 
 [[projects]]
+  digest = "1:68c64bb61d55dcd17c82ca0b871ddddb5ae18b30cfe26f6bfd4b6df6287dc2e0"
   name = "github.com/golang/mock"
   packages = ["gomock"]
+  pruneopts = ""
   revision = "9fa652df1129bef0e734c9cf9bf6dbae9ef3b9fa"
   version = "1.3.1"
 
 [[projects]]
+  digest = "1:b852d2b62be24e445fcdbad9ce3015b44c207815d631230dfce3f14e7803f5bf"
   name = "github.com/golang/protobuf"
-  packages = ["proto","protoc-gen-go/descriptor","ptypes","ptypes/any","ptypes/duration","ptypes/timestamp"]
+  packages = [
+    "proto",
+    "protoc-gen-go/descriptor",
+    "ptypes",
+    "ptypes/any",
+    "ptypes/duration",
+    "ptypes/timestamp",
+  ]
+  pruneopts = ""
   revision = "6c65a5562fc06764971b7c5d05c76c75e84bdbf7"
   version = "v1.3.2"
 
 [[projects]]
+  digest = "1:0536e7642a38c1683743ce8f1f6d83d9b3fc591a6cd911762f539283faec4132"
   name = "github.com/kelseyhightower/envconfig"
   packages = ["."]
+  pruneopts = ""
   revision = "0b417c4ec4a8a82eecc22a1459a504aa55163d61"
   version = "v1.4.0"
 
 [[projects]]
-  name = "github.com/pkg/errors"
-  packages = ["."]
-  revision = "614d223910a179a466c1767a985424175c39b465"
-  version = "v0.9.1"
-
-[[projects]]
+  digest = "1:256484dbbcd271f9ecebc6795b2df8cad4c458dd0f5fd82a8c2fa0c29f233411"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = ""
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:2761e287c811d0948d47d0252b82281eca3801eb3c9d5f9530956643d5b9f430"
   name = "github.com/russross/blackfriday"
   packages = ["."]
+  pruneopts = ""
   revision = "05f3235734ad95d0016f6a23902f06461fcf567a"
   version = "v1.5.2"
 
 [[projects]]
+  digest = "1:dfd60f86d731811aeae007175273be06ef7b90ef1212fda3b613da48fab69de7"
   name = "github.com/stianeikeland/go-rpio"
   packages = ["."]
+  pruneopts = ""
   revision = "d43a3ce8186d47f497a6785f997400a1b2f1fdc7"
   version = "v4.4.0"
 
 [[projects]]
+  digest = "1:f7b541897bcde05a04a044c342ddc7425aab7e331f37b47fbb486cd16324b48e"
   name = "github.com/stretchr/testify"
   packages = ["assert"]
+  pruneopts = ""
   revision = "221dbe5ed46703ee255b1da0dec05086f5035f62"
   version = "v1.4.0"
 
 [[projects]]
+  digest = "1:c6b7dd6b1f602f71a9522d03a65150ace6550839b71c543efa5686d56686c913"
   name = "github.com/urfave/cli"
   packages = ["."]
+  pruneopts = ""
   revision = "bfe2e925cfb6d44b40ad3a779165ea7e8aff9212"
   version = "v1.22.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:1d99703beb82a94d274f030c767a6d594fe645ec570b3fda450d0df82ea3c203"
   name = "github.com/yryz/ds18b20"
   packages = ["."]
+  pruneopts = ""
   revision = "3cf383a406247c49e48a80014f3e17ddee418742"
 
 [[projects]]
   branch = "master"
+  digest = "1:1de58c5f172054bd703e3abfc245557214c2c4a798d338eeeaadbe15a34db483"
   name = "golang.org/x/net"
-  packages = ["http/httpguts","http2","http2/hpack","idna","internal/timeseries","trace"]
+  packages = [
+    "http/httpguts",
+    "http2",
+    "http2/hpack",
+    "idna",
+    "internal/timeseries",
+    "trace",
+  ]
+  pruneopts = ""
   revision = "fc4aabc6c91483155dade6fbb627cc953a723260"
 
 [[projects]]
   branch = "master"
+  digest = "1:11845cae7402f689cdea0c89f6979f1e9ec2e15e413a4ebf6ce3d5eaee33aa87"
   name = "golang.org/x/sys"
   packages = ["unix"]
+  pruneopts = ""
   revision = "bd437916bb0eb726b873ee8e9b2dcf212d32e2fd"
 
 [[projects]]
+  digest = "1:740b51a55815493a8d0f2b1e0d0ae48fe48953bf7eaf3fcc4198823bf67768c0"
   name = "golang.org/x/text"
-  packages = ["collate","collate/build","internal/colltab","internal/gen","internal/language","internal/language/compact","internal/tag","internal/triegen","internal/ucd","language","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable"]
+  packages = [
+    "collate",
+    "collate/build",
+    "internal/colltab",
+    "internal/gen",
+    "internal/language",
+    "internal/language/compact",
+    "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
+    "language",
+    "secure/bidirule",
+    "transform",
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable",
+  ]
+  pruneopts = ""
   revision = "342b2e1fbaa52c93f31447ad2c6abc048c63e475"
   version = "v0.3.2"
 
 [[projects]]
   branch = "master"
+  digest = "1:a51a58f22fcdcf4238ee8b2a3a9637cbdb73320183038ce20c104f682563c640"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
+  pruneopts = ""
   revision = "83cc0476cb11ea0da33dacd4c6354ab192de6fe6"
 
 [[projects]]
+  digest = "1:52e042987a82bfe51831ac0de4d2fcaaf08e9042a6be0c39f8c8753320d529b3"
   name = "google.golang.org/grpc"
-  packages = [".","attributes","backoff","balancer","balancer/base","balancer/roundrobin","binarylog/grpc_binarylog_v1","codes","connectivity","credentials","credentials/internal","encoding","encoding/proto","grpclog","internal","internal/backoff","internal/balancerload","internal/binarylog","internal/buffer","internal/channelz","internal/envconfig","internal/grpcrand","internal/grpcsync","internal/resolver/dns","internal/resolver/passthrough","internal/syscall","internal/transport","keepalive","metadata","naming","peer","reflection","reflection/grpc_reflection_v1alpha","resolver","serviceconfig","stats","status","tap"]
+  packages = [
+    ".",
+    "attributes",
+    "backoff",
+    "balancer",
+    "balancer/base",
+    "balancer/roundrobin",
+    "binarylog/grpc_binarylog_v1",
+    "codes",
+    "connectivity",
+    "credentials",
+    "credentials/internal",
+    "encoding",
+    "encoding/proto",
+    "grpclog",
+    "internal",
+    "internal/backoff",
+    "internal/balancerload",
+    "internal/binarylog",
+    "internal/buffer",
+    "internal/channelz",
+    "internal/envconfig",
+    "internal/grpcrand",
+    "internal/grpcsync",
+    "internal/resolver/dns",
+    "internal/resolver/passthrough",
+    "internal/syscall",
+    "internal/transport",
+    "keepalive",
+    "metadata",
+    "naming",
+    "peer",
+    "reflection",
+    "reflection/grpc_reflection_v1alpha",
+    "resolver",
+    "serviceconfig",
+    "stats",
+    "status",
+    "tap",
+  ]
+  pruneopts = ""
   revision = "f495f5b15ae7ccda3b38c53a1bfcde4c1a58a2bc"
   version = "v1.27.1"
 
 [[projects]]
+  digest = "1:5a53f6ef09fb1ac261a97f8a72e8837ff53cbaa969022a6679da210e4cbe9b0f"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = ""
   revision = "1f64d6156d11335c3f22d9330b0ad14fc1e789ce"
   version = "v2.2.7"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "15e20601931ec205a338a26a20be8c3d8ab0ad1dc21b6cc3dd4af48505d9cc44"
+  input-imports = [
+    "github.com/golang/mock/gomock",
+    "github.com/golang/protobuf/proto",
+    "github.com/kelseyhightower/envconfig",
+    "github.com/stianeikeland/go-rpio",
+    "github.com/stretchr/testify/assert",
+    "github.com/urfave/cli",
+    "github.com/yryz/ds18b20",
+    "google.golang.org/grpc",
+    "google.golang.org/grpc/codes",
+    "google.golang.org/grpc/reflection",
+    "google.golang.org/grpc/status",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/brewery/Gopkg.lock
+++ b/brewery/Gopkg.lock
@@ -2,6 +2,14 @@
 
 
 [[projects]]
+  digest = "1:87f157a7bafc09d6a721a8768bbce5d744066dcc18e586e3a25826f2bdf516fa"
+  name = "github.com/brian-armstrong/gpio"
+  packages = ["."]
+  pruneopts = ""
+  revision = "3846dfc1984fa6404f927b6a332452c9990a2d6c"
+  version = "v1.0"
+
+[[projects]]
   digest = "1:141635a36d65611d06a05ec1d17be950e386426b6540169fe7c9476df41f6493"
   name = "github.com/cpuguy83/go-md2man"
   packages = ["md2man"]
@@ -211,6 +219,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/brian-armstrong/gpio",
     "github.com/golang/mock/gomock",
     "github.com/golang/protobuf/proto",
     "github.com/kelseyhightower/envconfig",

--- a/brewery/Gopkg.toml
+++ b/brewery/Gopkg.toml
@@ -49,9 +49,5 @@
   name = "github.com/yryz/ds18b20"
 
 [[constraint]]
-  branch = "master"
-  name = "golang.org/x/net"
-
-[[constraint]]
   name = "google.golang.org/grpc"
   version = "1.27.0"

--- a/brewery/Makefile
+++ b/brewery/Makefile
@@ -80,7 +80,7 @@ client:
 	docker push mkuchenbecker/brewery3:client-latest
 
 
-.PHONY: build-base
+.PHONY: base
 build-base:
 	docker build --no-cache -t local/base -f base.dockerfile . \
 	&& docker tag local/base mkuchenbecker/brewery3:base-latest \

--- a/brewery/Makefile
+++ b/brewery/Makefile
@@ -82,7 +82,7 @@ client:
 
 .PHONY: build-base
 build-base:
-	docker build  -t local/base -f base.dockerfile . \
+	docker build --no-cache -t local/base -f base.dockerfile . \
 	&& docker tag local/base mkuchenbecker/brewery3:base-latest \
 	&& docker push mkuchenbecker/brewery3:base-latest
 

--- a/brewery/Makefile
+++ b/brewery/Makefile
@@ -92,15 +92,15 @@ build: controller element thermometer
 
 .PHONY: controller
 controller:
-	docker build --no-cache -t mkuchenbecker/brewery3:base-latest -f controller.dockerfile . \
+	docker build --no-cache -t mkuchenbecker/brewery3:controller-latest -f controller.dockerfile . \
 
 .PHONY: thermometer
 thermometer:
-	docker build --no-cache -t mkuchenbecker/brewery3:base-latest -f thermometer.dockerfile . \
+	docker build --no-cache -t mkuchenbecker/brewery3:thermometer-latest -f thermometer.dockerfile . \
 
 .PHONY: element
 element:
-	docker build --no-cache -t mkuchenbecker/brewery3:base-latest -f element.dockerfile .
+	docker build --no-cache -t mkuchenbecker/brewery3:element-latest -f element.dockerfile .
 
 .PHONY: cli
 cli:

--- a/brewery/Makefile
+++ b/brewery/Makefile
@@ -91,15 +91,15 @@ build: controller element thermometer
 
 .PHONY: controller
 controller:
-	docker build  -t local/controller -f controller.dockerfile . \
+	docker build --no-cache -t mkuchenbecker/brewery3:base-latest -f controller.dockerfile . \
 
 .PHONY: thermometer
 thermometer:
-	docker build  -t local/thermometer -f thermometer.dockerfile . \
+	docker build --no-cache -t mkuchenbecker/brewery3:base-latest -f thermometer.dockerfile . \
 
 .PHONY: element
 element:
-	docker build  -t local/element -f element.dockerfile .
+	docker build --no-cache -t mkuchenbecker/brewery3:base-latest -f element.dockerfile .
 
 .PHONY: cli
 cli:

--- a/brewery/Makefile
+++ b/brewery/Makefile
@@ -81,13 +81,14 @@ client:
 
 
 .PHONY: base
-build-base:
+base:
 	docker build --no-cache -t local/base -f base.dockerfile . \
 	&& docker tag local/base mkuchenbecker/brewery3:base-latest \
 	&& docker push mkuchenbecker/brewery3:base-latest
 
 .PHONY: build
 build: controller element thermometer
+	echo "success"
 
 .PHONY: controller
 controller:

--- a/brewery/brewery.yml
+++ b/brewery/brewery.yml
@@ -54,11 +54,7 @@ spec:
               cpu: "250m"
           args:
             - --privileged
-            - --device=/dev/mem
-            - --device=/dev/gpiomem
           volumeMounts:
-            - mountPath: /dev/mem
-              name: dev-mem
             - mountPath: /sys/class/gpio
               name: sysfs-gpio
           securityContext:

--- a/brewery/brewery.yml
+++ b/brewery/brewery.yml
@@ -134,8 +134,8 @@ spec:
           hostPath:
             path: /sys/class/gpio
         - name: sysfs-gpio5
-            hostPath:
-              path: /sys/class/gpio/gpio5
+          hostPath:
+            path: /sys/class/gpio/gpio5
 ---
 apiVersion: v1
 kind: Service

--- a/brewery/brewery.yml
+++ b/brewery/brewery.yml
@@ -57,6 +57,8 @@ spec:
           volumeMounts:
             - mountPath: /sys/class/gpio
               name: sysfs-gpio
+            - mountPath: /sys/class/gpio/gpio5
+              name: sysfs-gpio5
           securityContext:
             privileged: true
           env:
@@ -131,6 +133,9 @@ spec:
         - name: sysfs-gpio
           hostPath:
             path: /sys/class/gpio
+        - name: sysfs-gpio5
+            hostPath:
+              path: /sys/class/gpio/gpio5
 ---
 apiVersion: v1
 kind: Service

--- a/brewery/brewery.yml
+++ b/brewery/brewery.yml
@@ -59,6 +59,8 @@ spec:
           volumeMounts:
             - mountPath: /dev/mem
               name: dev-mem
+            - mountPath: /sys/class/gpio
+              name: sysfs-gpio
           securityContext:
             privileged: true
           env:
@@ -130,6 +132,9 @@ spec:
         - name: dev-mem
           hostPath:
             path: /dev/mem
+        - name: sysfs-gpio
+          hostPath:
+            path: /sys/class/gpio
 ---
 apiVersion: v1
 kind: Service

--- a/brewery/controller/controller/brewery.go
+++ b/brewery/controller/controller/brewery.go
@@ -108,7 +108,9 @@ func (b *Brewery) run() error {
 		utils.Print(fmt.Sprintf("Mashing: %+v", sch.Mash))
 		return b.mash()
 	case *model.ControlScheme_Boil_:
-		return b.elementOn(context.Background()) // Toggle for one hour.
+		return b.elementOn(context.Background())
+	case *model.ControlScheme_Off_:
+		return b.elementOff(context.Background())
 	}
 	return nil
 }

--- a/brewery/element/element/heater.go
+++ b/brewery/element/element/heater.go
@@ -50,11 +50,15 @@ func StartElement(pinNum int64, port int64) {
 	}
 	serve := grpc.NewServer()
 
+	utils.Print("setting pu pins")
 	pins := integration.SysfsPins{}
+	utils.Print("opening GPIO")
 	if err = pins.Open(); err != nil {
 		log.Fatalf("failed to open gpio: %v", err)
 	}
 	defer pins.Close()
+
+	utils.Print("getting pin")
 	pin := pins.Pin(uint(pinNum))
 	pin.Output()
 

--- a/brewery/element/element/heater.go
+++ b/brewery/element/element/heater.go
@@ -50,12 +50,12 @@ func StartElement(pinNum int64, port int64) {
 	}
 	serve := grpc.NewServer()
 
-	pins := integration.DefaultPins{}
+	pins := integration.SysfsPins{}
 	if err = pins.Open(); err != nil {
 		log.Fatalf("failed to open gpio: %v", err)
 	}
 	defer pins.Close()
-	pin := pins.Pin(uint8(pinNum))
+	pin := pins.Pin(uint(pinNum))
 	pin.Output()
 
 	for i := 0; i < 60; i++ {

--- a/brewery/element/element/heater.go
+++ b/brewery/element/element/heater.go
@@ -2,11 +2,18 @@ package element
 
 import (
 	"context"
+	"fmt"
+	"log"
+	"net"
 
+	"github.com/mkuchenbecker/brewery3/brewery/gpio/integration"
 	"github.com/mkuchenbecker/brewery3/brewery/utils"
 
 	"github.com/mkuchenbecker/brewery3/brewery/gpio"
+
 	model "github.com/mkuchenbecker/brewery3/brewery/model/gomodel"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
 )
 
 // HeaterServer implements switch.
@@ -32,4 +39,29 @@ func (s *HeaterServer) Off(ctx context.Context, req *model.OffRequest) (*model.O
 	utils.Print("Heater Off")
 	s.elementPin.Low()
 	return &model.OffResponse{}, nil
+}
+
+func StartElement(pinNum int64, port int64) {
+	utils.Printf("Starting heater on port: %d; pin: %d", port, pinNum)
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		log.Fatalf("failed to listen: %v", err)
+	}
+	serve := grpc.NewServer()
+
+	pins := integration.DefaultPins{}
+	if err = pins.Open(); err != nil {
+		log.Fatalf("failed to open gpio: %v", err)
+	}
+	defer pins.Close()
+	pin := pins.Pin(uint8(pinNum))
+	pin.Output()
+
+	heater := NewHeaterServer(pin)
+	model.RegisterSwitchServer(serve, heater)
+	// Register reflection service on gRPC server.
+	reflection.Register(serve)
+	if err := serve.Serve(lis); err != nil {
+		log.Fatalf("failed to serve: %v", err)
+	}
 }

--- a/brewery/element/element/heater.go
+++ b/brewery/element/element/heater.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"net"
-	"time"
 
 	"github.com/mkuchenbecker/brewery3/brewery/gpio/integration"
 	"github.com/mkuchenbecker/brewery3/brewery/utils"
@@ -50,9 +49,8 @@ func StartElement(pinNum int64, port int64) {
 	}
 	serve := grpc.NewServer()
 
-	utils.Print("setting pu pins")
+	utils.Print("setting up pins")
 	pins := integration.SysfsPins{}
-	utils.Print("opening GPIO")
 	if err = pins.Open(); err != nil {
 		log.Fatalf("failed to open gpio: %v", err)
 	}
@@ -61,15 +59,6 @@ func StartElement(pinNum int64, port int64) {
 	utils.Print("getting pin")
 	pin := pins.Pin(uint(pinNum))
 	pin.Output()
-
-	for i := 0; i < 60; i++ {
-		utils.Printf("on %d", pinNum)
-		pin.High()
-		time.Sleep(time.Second)
-		utils.Printf("off %d", pinNum)
-		pin.Low()
-		time.Sleep(time.Second)
-	}
 
 	heater := NewHeaterServer(pin)
 	model.RegisterSwitchServer(serve, heater)

--- a/brewery/element/element/heater.go
+++ b/brewery/element/element/heater.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"time"
 
 	"github.com/mkuchenbecker/brewery3/brewery/gpio/integration"
 	"github.com/mkuchenbecker/brewery3/brewery/utils"
@@ -56,6 +57,15 @@ func StartElement(pinNum int64, port int64) {
 	defer pins.Close()
 	pin := pins.Pin(uint8(pinNum))
 	pin.Output()
+
+	for i := 0; i < 60; i++ {
+		utils.Printf("on %d", pinNum)
+		pin.High()
+		time.Sleep(time.Second)
+		utils.Printf("off %d", pinNum)
+		pin.Low()
+		time.Sleep(time.Second)
+	}
 
 	heater := NewHeaterServer(pin)
 	model.RegisterSwitchServer(serve, heater)

--- a/brewery/element/main.go
+++ b/brewery/element/main.go
@@ -1,19 +1,11 @@
 package main
 
 import (
-	"fmt"
 	"log"
-	"net"
 	"os"
 	"strconv"
 
-	"github.com/mkuchenbecker/brewery3/brewery/utils"
-
 	"github.com/mkuchenbecker/brewery3/brewery/element/element"
-	"github.com/mkuchenbecker/brewery3/brewery/gpio/integration"
-	model "github.com/mkuchenbecker/brewery3/brewery/model/gomodel"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/reflection"
 )
 
 func main() { // nolint: deadcode
@@ -30,27 +22,6 @@ func main() { // nolint: deadcode
 		log.Fatalf("invalid pin : %s", strPin)
 	}
 
-	utils.Printf("Starting heater on port: %d; pin: %d", port, pinNum)
+	element.StartElement(pinNum, port)
 
-	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
-	if err != nil {
-		log.Fatalf("failed to listen: %v", err)
-	}
-	serve := grpc.NewServer()
-
-	pins := integration.DefaultPins{}
-	if err = pins.Open(); err != nil {
-		log.Fatalf("failed to open gpio: %v", err)
-	}
-	defer pins.Close()
-	pin := pins.Pin(uint8(pinNum))
-	pin.Output()
-
-	heater := element.NewHeaterServer(pin)
-	model.RegisterSwitchServer(serve, heater)
-	// Register reflection service on gRPC server.
-	reflection.Register(serve)
-	if err := serve.Serve(lis); err != nil {
-		log.Fatalf("failed to serve: %v", err)
-	}
 }

--- a/brewery/gpio/integration/pins.go
+++ b/brewery/gpio/integration/pins.go
@@ -1,7 +1,9 @@
 package integration
 
 import (
+	sysfsGPIO "github.com/brian-armstrong/gpio"
 	"github.com/mkuchenbecker/brewery3/brewery/gpio"
+	"github.com/mkuchenbecker/brewery3/brewery/utils"
 	rpio "github.com/stianeikeland/go-rpio"
 )
 
@@ -18,4 +20,36 @@ func (d *DefaultPins) Close() error {
 
 func (d *DefaultPins) Pin(pin uint8) gpio.Pin {
 	return rpio.Pin(pin)
+}
+
+type SysfsPins struct {
+}
+
+func (d *SysfsPins) Open() error {
+	return nil
+}
+
+func (d *SysfsPins) Close() error {
+	return nil
+}
+
+func (d *SysfsPins) Pin(pin uint) gpio.Pin {
+	return &sysfsPin{pin: sysfsGPIO.NewOutput(pin, false)}
+}
+
+type sysfsPin struct {
+	pin sysfsGPIO.Pin
+}
+
+func (pin *sysfsPin) High() {
+	err := pin.pin.High()
+	utils.LogIfError(&utils.DefualtPrinter{}, err, "error setting pin high")
+}
+
+func (pin *sysfsPin) Low() {
+	err := pin.pin.Low()
+	utils.LogIfError(&utils.DefualtPrinter{}, err, "error setting pin high")
+}
+
+func (pin *sysfsPin) Output() {
 }

--- a/brewery/gpio/integration/pins.go
+++ b/brewery/gpio/integration/pins.go
@@ -34,6 +34,7 @@ func (d *SysfsPins) Close() error {
 }
 
 func (d *SysfsPins) Pin(pin uint) gpio.Pin {
+	utils.Printf("getting pin: %d", pin)
 	return &sysfsPin{pin: sysfsGPIO.NewOutput(pin, false)}
 }
 
@@ -43,12 +44,16 @@ type sysfsPin struct {
 
 func (pin *sysfsPin) High() {
 	err := pin.pin.High()
-	utils.LogIfError(&utils.DefualtPrinter{}, err, "error setting pin high")
+	if err != nil {
+		utils.Printf("error setting pin high: %+v", err)
+	}
 }
 
 func (pin *sysfsPin) Low() {
 	err := pin.pin.Low()
-	utils.LogIfError(&utils.DefualtPrinter{}, err, "error setting pin high")
+	if err != nil {
+		utils.Printf("error setting pin low: %+v", err)
+	}
 }
 
 func (pin *sysfsPin) Output() {

--- a/brewery/main.go
+++ b/brewery/main.go
@@ -1,9 +1,24 @@
 package main
 
 import (
-	"github.com/mkuchenbecker/brewery3/brewery/element/element"
+	"log"
+	"time"
+
+	"github.com/mkuchenbecker/brewery3/brewery/gpio/integration"
 )
 
 func main() {
-	element.StartElement(5, 9100)
+	pins := integration.DefaultPins{}
+	if err := pins.Open(); err != nil {
+		log.Fatalf("failed to open gpio: %v", err)
+	}
+	defer pins.Close()
+	pin := pins.Pin(uint8(5))
+	pin.Output()
+	for {
+		pin.High()
+		time.Sleep(time.Second)
+		pin.Low()
+		time.Sleep(time.Second)
+	}
 }

--- a/brewery/main.go
+++ b/brewery/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/mkuchenbecker/brewery3/brewery/element/element"
+)
+
+func main() {
+	element.StartElement(5, 9100)
+}

--- a/brewery/model/gomodel/config.pb.go
+++ b/brewery/model/gomodel/config.pb.go
@@ -6,11 +6,12 @@ package brewery_model
 import (
 	context "context"
 	fmt "fmt"
+	math "math"
+
 	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.


### PR DESCRIPTION
sysfs is deprecated but I was unable to get GPIO working with /dev/mem. I would get no errors but it was not actually powering the pins. sysfs will be removed in 2020 at some point and has been deprecated for a number of years, but it works as a volume mount. 